### PR TITLE
Fix Firestore initialization bug

### DIFF
--- a/app/src/main/java/com/example/loyalisttest/utils/FirestoreInitUtils.kt
+++ b/app/src/main/java/com/example/loyalisttest/utils/FirestoreInitUtils.kt
@@ -12,12 +12,17 @@ object FirestoreInitUtils {
     /**
      * Инициализирует коллекции Firestore для нового пользователя
      */
-    suspend fun initializeCollections(userId: String, email: String, name: String, isFirstUser: Boolean): Result<Unit> {
-        return try {
-            Log.d(TAG, "Starting initialization for user: $userId, isFirstUser: $isFirstUser")
+suspend fun initializeCollections(
+    userId: String,
+    email: String,
+    name: String,
+    isFirstUserFlag: Boolean
+): Result<Unit> {
+    return try {
+        Log.d(TAG, "Starting initialization for user: $userId, isFirstUser: $isFirstUserFlag")
 
-            // Проверяем, действительно ли это первый пользователь
-            val actuallyFirst = isFirstUser && isFirstUser()
+        // Проверяем, действительно ли это первый пользователь
+        val actuallyFirst = isFirstUserFlag && isFirstUser()
             Log.d(TAG, "Verified first user status: $actuallyFirst")
 
             // Определяем роль пользователя


### PR DESCRIPTION
## Summary
- fix variable name collision in `FirestoreInitUtils.initializeCollections`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68404ad6aecc8333b258a95d9445fbbb